### PR TITLE
add support for updated product name ("FRITZ!Smart Energy 2xx") for FRITZ!Dect 2xx

### DIFF
--- a/fritzapi/src/devices/device_impl.rs
+++ b/fritzapi/src/devices/device_impl.rs
@@ -19,16 +19,20 @@ impl AVMDevice {
                     }),
                 temperature: Some(Temperature { celsius, .. }),
                 ..
-            } if productname.starts_with("FRITZ!DECT 2") => AVMDevice::FritzDect2XX(FritzDect2XX {
-                identifier,
-                productname,
-                name,
-                on: state,
-                millivolts: voltage,
-                milliwatts: power,
-                energy_in_watt_h: energy,
-                celsius: celsius.parse::<f32>().unwrap_or_default() * 0.1,
-            }),
+            } if productname.starts_with("FRITZ!DECT 2")
+                || productname.starts_with("FRITZ!Smart Energy 2") =>
+            {
+                AVMDevice::FritzDect2XX(FritzDect2XX {
+                    identifier,
+                    productname,
+                    name,
+                    on: state,
+                    millivolts: voltage,
+                    milliwatts: power,
+                    energy_in_watt_h: energy,
+                    celsius: celsius.parse::<f32>().unwrap_or_default() * 0.1,
+                })
+            }
 
             _ => AVMDevice::Other(device),
         }


### PR DESCRIPTION
I'm using the `fritzapi` crate to read data from a FRITZ!Dect 210 smart plug and my program stopped working a couple of weeks ago. The root cause seems to be that with the latest firmware, the `productname` reported by the device changed such that it isn't recognized by fritzapi anymore.

Here's how the device is reported:

```
Device {
    ...
    fwversion: "04.27",
    manufacturer: "AVM",
    productname: "FRITZ!Smart Energy 210",
    ...
}
```

The change is intentional and also in the official release notes: https://en.avm.de/service/update-news/?product=fritzdect-210

> FRITZ!DECT 210 was renamed to FRITZ!Smart Energy 210

This PR changes the device detection logic such that the new product name is also recognized as being a `FritzDect2XX`.

Let me know if you have questions.